### PR TITLE
use symbolize_keys for legacy yajl-ruby compatibility

### DIFF
--- a/lib/honeybadger-api/client.rb
+++ b/lib/honeybadger-api/client.rb
@@ -15,7 +15,7 @@ module Honeybadger
 
       def get(path, options = {})
         response = request(path, options)
-        JSON.parse(response.body, :symbolize_names => true)
+        JSON.parse(response.body, :symbolize_names => true, :symbolize_keys => true)
       end
 
       private


### PR DESCRIPTION
Version 1.1.0 of `yajl-ruby` uses `symbolize_keys` instead of `symbolize_names` to parse the JSON string into a hash where the keys are symbols. 