### PR TITLE
Pin factory girl dependency and active support. 

### DIFF
--- a/honeybadger-api.gemspec
+++ b/honeybadger-api.gemspec
@@ -22,5 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '3.4.0'
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'mocha'
-  spec.add_development_dependency 'factory_girl'
+  spec.add_development_dependency 'factory_girl', '4.7.0'
+  spec.add_development_dependency 'activesupport', '4.2.6'
 end


### PR DESCRIPTION
Active Support 5 requires >= Ruby 2.2.2

So that specs run under 2.1.8 pin factory girl and subsequently active support. 