### PR TITLE
The deploy attribute on the notices resource is optional returned.

### DIFF
--- a/lib/honeybadger-api/notice.rb
+++ b/lib/honeybadger-api/notice.rb
@@ -19,7 +19,7 @@ module Honeybadger
         @cookies = opts[:cookies]
         @web_environment = opts[:web_environment]
         @backtrace = opts[:backtrace]
-        @deploy = Deploy.new(opts[:deploy])
+        @deploy = Deploy.new(opts[:deploy]) if !opts[:deploy].nil?
         @message = opts[:message]
         @request = opts[:request]
         @created_at = opts[:created_at].nil? ? nil : DateTime.parse(opts[:created_at])

--- a/lib/honeybadger-api/version.rb
+++ b/lib/honeybadger-api/version.rb
@@ -1,5 +1,5 @@
 module Honeybadger
   module Api
-    VERSION = "2.0.0"
+    VERSION = "2.0.1"
   end
 end

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "Honeybadger::Api::VERSION" do
-  it "should be version 2.0.0" do
-    expect(Honeybadger::Api::VERSION).to eql("2.0.0")
+  it "should be version 2.0.1" do
+    expect(Honeybadger::Api::VERSION).to eql("2.0.1")
   end
 end


### PR DESCRIPTION
The deploy attribute isn't always returned on the notices resource from the Read API. Update the notices resource to make the deploy attribute optional.

Resolves #26 