### PR TITLE
Add support for sites, outages and uptime check endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in honeybadger-api.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -132,10 +132,10 @@ Honeybadger::Api::Notice.paginate(project_id, fault_id)
 # Find a comment
 Honeybadger::Api::Comment.find(project_id, fault_id, comment_id)
 
-# Find all the comments 
+# Find all the comments
 Honeybadger::Api::Comment.all(project_id, fault_id)
 
-# Retrieve a paginator for comments 
+# Retrieve a paginator for comments
 Honeybadger::Api::Comment.paginate(project_id, fault_id)
 ```
 
@@ -159,20 +159,32 @@ Honeybadger::Api::TeamMember.find(team_id, team_member_id)
 # Find all the team members
 Honeybadger::Api::TeamMember.all(team_id)
 
-# Retrieve a paginator for team members 
+# Retrieve a paginator for team members
 Honeybadger::Api::TeamMember.paginate(team_id)
 ```
 
 ### Team Invitations
 ```
-# Find a team invitation 
+# Find a team invitation
 Honeybadger::Api::TeamInvitation.find(team_id, team_invitation_id)
 
-# Find all the team invitations 
+# Find all the team invitations
 Honeybadger::Api::TeamInvitation.all(team_id)
 
-# Retrieve a paginator for team invitations 
+# Retrieve a paginator for team invitations
 Honeybadger::Api::TeamInvitation.paginate(team_id)
+```
+
+### Sites
+```
+# Find a site
+Honeybadger::Api::Site.find(project_id, site_id)
+
+# Find all the sites
+Honeybadger::Api::Site.all(project_id)
+
+# Retrieve a paginator for sites
+Honeybadger::Api::Site.paginate(project_id)
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -187,6 +187,15 @@ Honeybadger::Api::Site.all(project_id)
 Honeybadger::Api::Site.paginate(project_id)
 ```
 
+### Outages
+```
+# Find all the outages
+Honeybadger::Api::Outage.all(project_id, site_id)
+
+# Retrieve a paginator for outages
+Honeybadger::Api::Outage.paginate(project_id, site_id)
+```
+
 ### Uptime Checks
 ```
 # Find all the uptime checks

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Ruby Library for the [Honeybadger Read API](https://www.honeybadger.io/documen
 
 Add this line to your application's Gemfile:
 
-    gem 'honeybadger-api'
+    gem "honeybadger-api"
 
 And then execute:
 
@@ -22,14 +22,14 @@ Or install it yourself as:
 Firstly require the library:
 
 ```
-require 'honeybadger-api'
+require "honeybadger-api"
 ```
 
 Then configure your personal API access token. Your personal API access token can be found on your [personal profile page](https://www.honeybadger.io/users/edit):
 
 ```
 Honeybadger::Api.configure do |c|
-  c.access_token = 'xxxxxxxxxxxxxxxxxxxx'
+  c.access_token = "xxxxxxxxxxxxxxxxxxxx"
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,15 @@ Honeybadger::Api::Site.all(project_id)
 Honeybadger::Api::Site.paginate(project_id)
 ```
 
+### Uptime Checks
+```
+# Find all the uptime checks
+Honeybadger::Api::UptimeCheck.all(project_id, site_id)
+
+# Retrieve a paginator for uptime checks
+Honeybadger::Api::UptimeCheck.paginate(project_id, site_id)
+```
+
 ## Contributing
 
 1. Fork it

--- a/honeybadger-api.gemspec
+++ b/honeybadger-api.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'honeybadger-api/version'
+require "honeybadger-api/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "honeybadger-api"
@@ -17,11 +17,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'json'
+  spec.add_runtime_dependency "json"
 
-  spec.add_development_dependency 'rspec', '3.4.0'
-  spec.add_development_dependency 'webmock'
-  spec.add_development_dependency 'mocha'
-  spec.add_development_dependency 'factory_girl', '4.7.0'
-  spec.add_development_dependency 'activesupport', '4.2.6'
+  spec.add_development_dependency "rspec", "3.4.0"
+  spec.add_development_dependency "webmock"
+  spec.add_development_dependency "mocha"
+  spec.add_development_dependency "factory_girl", "4.7.0"
+  spec.add_development_dependency "activesupport", "4.2.6"
 end

--- a/lib/honeybadger-api.rb
+++ b/lib/honeybadger-api.rb
@@ -16,6 +16,7 @@ require "honeybadger-api/fault"
 require "honeybadger-api/notice"
 require "honeybadger-api/site"
 require "honeybadger-api/uptime_check"
+require "honeybadger-api/outage"
 
 module Honeybadger
   module Api

--- a/lib/honeybadger-api.rb
+++ b/lib/honeybadger-api.rb
@@ -15,6 +15,7 @@ require "honeybadger-api/project"
 require "honeybadger-api/fault"
 require "honeybadger-api/notice"
 require "honeybadger-api/site"
+require "honeybadger-api/uptime_check"
 
 module Honeybadger
   module Api

--- a/lib/honeybadger-api.rb
+++ b/lib/honeybadger-api.rb
@@ -1,4 +1,4 @@
-require 'date'
+require "date"
 
 require "honeybadger-api/version"
 require "honeybadger-api/configuration"
@@ -14,6 +14,7 @@ require "honeybadger-api/comment"
 require "honeybadger-api/project"
 require "honeybadger-api/fault"
 require "honeybadger-api/notice"
+require "honeybadger-api/site"
 
 module Honeybadger
   module Api

--- a/lib/honeybadger-api/outage.rb
+++ b/lib/honeybadger-api/outage.rb
@@ -1,0 +1,39 @@
+module Honeybadger
+  module Api
+    class Outage
+
+      attr_reader :down_at, :up_at, :created_at, :status, :reason, :headers
+
+      # Public: Build a new instance of Outage
+      #
+      # opts - A Hash of attributes to initialize an Outage
+      #
+      # Returns a new Outage
+      def initialize(opts)
+        @down_at = opts[:down_at].nil? ? nil : DateTime.parse(opts[:down_at])
+        @up_at = opts[:up_at].nil? ? nil : DateTime.parse(opts[:up_at])
+        @created_at = opts[:created_at].nil? ? nil : DateTime.parse(opts[:created_at])
+        @status = opts[:status]
+        @reason = opts[:reason]
+        @headers = opts[:headers]
+      end
+
+      # Public: Find all outages for a given project and site.
+      def self.all(project_id, site_id)
+        path = "projects/#{project_id}/sites/#{site_id}/outages"
+        Honeybadger::Api::Request.all(path, handler)
+      end
+
+      # Public: Paginate all outages for a given project and site.
+      def self.paginate(project_id, site_id, filters = {})
+        path = "projects/#{project_id}/sites/#{site_id}/outages"
+        Honeybadger::Api::Request.paginate(path, handler, filters)
+      end
+
+      # Internal: The handler used to build objects from API responses.
+      def self.handler
+        Proc.new { |response| Outage.new(response) }
+      end
+    end
+  end
+end

--- a/lib/honeybadger-api/site.rb
+++ b/lib/honeybadger-api/site.rb
@@ -1,0 +1,49 @@
+module Honeybadger
+  module Api
+    class Site
+
+      attr_reader :active, :frequency, :id, :last_checked_at,
+        :match, :match_type, :name, :state, :url
+
+      # Public: Build a new instance of Site
+      #
+      # opts - A Hash of attributes to initialize a Site
+      #
+      # Returns a new Site
+      def initialize(opts)
+        @active = opts[:active]
+        @frequency = opts[:frequency]
+        @id = opts[:id]
+        @last_checked_at = opts[:last_checked_at].nil? ? nil : DateTime.parse(opts[:last_checked_at])
+        @match = opts[:match]
+        @match_type = opts[:match_type]
+        @name = opts[:name]
+        @state = opts[:state]
+        @url = opts[:url]
+      end
+
+      # Public: Find all sites for a given project.
+      def self.all(project_id)
+        path  = "projects/#{project_id}/sites"
+        Honeybadger::Api::Request.all(path, handler)
+      end
+
+      # Public: Paginate all sites for a given project.
+      def self.paginate(project_id, filters = {})
+        path  = "projects/#{project_id}/sites"
+        Honeybadger::Api::Request.paginate(path, handler, filters)
+      end
+
+      # Public: Find a site for a given project.
+      def self.find(project_id, site_id)
+        path = "projects/#{project_id}/sites/#{site_id}"
+        Honeybadger::Api::Request.find(path, handler)
+      end
+
+      # Internal: The handler used to build objects from API responses.
+      def self.handler
+        Proc.new { |response| Site.new(response) }
+      end
+    end
+  end
+end

--- a/lib/honeybadger-api/uptime_check.rb
+++ b/lib/honeybadger-api/uptime_check.rb
@@ -1,0 +1,37 @@
+module Honeybadger
+  module Api
+    class UptimeCheck
+
+      attr_reader :up, :location, :duration, :created_at
+
+      # Public: Build a new instance of UptimeCheck
+      #
+      # opts - A Hash of attributes to initialize a UptimeCheck
+      #
+      # Returns a new UptimeCheck
+      def initialize(opts)
+        @up = opts[:up]
+        @location = opts[:location]
+        @duration = opts[:duration]
+        @created_at = opts[:created_at].nil? ? nil : DateTime.parse(opts[:created_at])
+      end
+
+      # Public: Find all uptime checks for a given project and site.
+      def self.all(project_id, site_id)
+        path = "projects/#{project_id}/sites/#{site_id}/uptime_checks"
+        Honeybadger::Api::Request.all(path, handler)
+      end
+
+      # Public: Paginate all uptime checks for a given project and site.
+      def self.paginate(project_id, site_id, filters = {})
+        path = "projects/#{project_id}/sites/#{site_id}/uptime_checks"
+        Honeybadger::Api::Request.paginate(path, handler, filters)
+      end
+
+      # Internal: The handler used to build objects from API responses.
+      def self.handler
+        Proc.new { |response| UptimeCheck.new(response) }
+      end
+    end
+  end
+end

--- a/lib/honeybadger-api/version.rb
+++ b/lib/honeybadger-api/version.rb
@@ -1,5 +1,5 @@
 module Honeybadger
   module Api
-    VERSION = "2.0.1"
+    VERSION = "2.1.0"
   end
 end

--- a/spec/comment_spec.rb
+++ b/spec/comment_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Honeybadger::Api::Comment do
 
@@ -65,7 +65,7 @@ describe Honeybadger::Api::Comment do
       @fault_id = 2
       @path = "projects/#{@project_id}/faults/#{@fault_id}/comments"
       @handler = Proc.new { |response| Comment.new(response) }
-      @filters = { some_filter: 'value' }
+      @filters = { some_filter: "value" }
       Honeybadger::Api::Comment.expects(:handler).returns(@handler)
     end
 

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Honeybadger::Api::Deploy do
   
@@ -55,7 +55,7 @@ describe Honeybadger::Api::Deploy do
       @project_id = 1
       @path = "projects/#{@project_id}/deploys"
       @handler = Proc.new { |response| Deploy.new(response) }
-      @filters = { some_filter: 'value' }
+      @filters = { some_filter: "value" }
       Honeybadger::Api::Deploy.expects(:handler).returns(@handler)
     end
 

--- a/spec/factories/outage_factory.rb
+++ b/spec/factories/outage_factory.rb
@@ -1,0 +1,20 @@
+FactoryGirl.define do
+  factory :outage, :class => Honeybadger::Api::Outage do
+    down_at "2015-02-17T18:20:44.776959Z"
+    up_at "2015-02-17T18:22:35.614678Z"
+    created_at "2015-02-17T18:20:44.777914Z"
+    status 301
+    reason "Expected 2xx status code. Got 301"
+    headers({
+      :date => "Tue, 17 Feb 2015 18:20:44 GMT",
+      :server => "DNSME HTTP Redirection",
+      :location => "http://text.vote/polls",
+      :connection => "close",
+      :content_length => "0"
+    })
+
+    initialize_with do
+      new(attributes)
+    end
+  end
+end

--- a/spec/factories/site_factory.rb
+++ b/spec/factories/site_factory.rb
@@ -1,0 +1,17 @@
+FactoryGirl.define do
+  factory :site, :class => Honeybadger::Api::Site do
+    id "9eed6a7e-af77-4cc6-8c55-b7b17555330d"
+    active true
+    frequency 5
+    last_checked_at "2016-06-15T12:57:29.646956Z"
+    match nil
+    match_type "success"
+    name "Main site"
+    state "down"
+    url "http://www.example.com"
+
+    initialize_with do
+      new(attributes)
+    end
+  end
+end

--- a/spec/factories/uptime_check_factory.rb
+++ b/spec/factories/uptime_check_factory.rb
@@ -1,0 +1,12 @@
+FactoryGirl.define do
+  factory :uptime_check, :class => Honeybadger::Api::UptimeCheck do
+    up true
+    location "Singapore"
+    duration 1201
+    created_at "2016-06-16T20:19:32.852569Z"
+
+    initialize_with do
+      new(attributes)
+    end
+  end
+end

--- a/spec/fault_spec.rb
+++ b/spec/fault_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Honeybadger::Api::Fault do
 
-  describe "initializing a new comment" do
+  describe "initializing a new fault" do
     before :all do
       @fault = FactoryGirl.build :fault
     end

--- a/spec/fault_spec.rb
+++ b/spec/fault_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Honeybadger::Api::Fault do
 
@@ -135,7 +135,7 @@ describe Honeybadger::Api::Fault do
       @project_id = 1
       @path = "projects/#{@project_id}/faults"
       @handler = Proc.new { |response| Fault.new(response) }
-      @filters = { some_filter: 'value' }
+      @filters = { some_filter: "value" }
       Honeybadger::Api::Fault.expects(:handler).returns(@handler)
     end
 

--- a/spec/notice_spec.rb
+++ b/spec/notice_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Honeybadger::Api::Notice do
 
@@ -99,7 +99,7 @@ describe Honeybadger::Api::Notice do
       @fault_id = 2
       @path = "projects/#{@project_id}/faults/#{@fault_id}/notices"
       @handler = Proc.new { |response| Notice.new(response) }
-      @filters = { some_filter: 'value' }
+      @filters = { some_filter: "value" }
       Honeybadger::Api::Notice.expects(:handler).returns(@handler)
     end
 

--- a/spec/outage_spec.rb
+++ b/spec/outage_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Honeybadger::Api::Outage do
 
-  describe "initializing a new site" do
+  describe "initializing a new outage" do
     before :all do
       @outage = FactoryGirl.build :outage
     end

--- a/spec/outage_spec.rb
+++ b/spec/outage_spec.rb
@@ -1,0 +1,72 @@
+require "spec_helper"
+
+describe Honeybadger::Api::Outage do
+
+  describe "initializing a new site" do
+    before :all do
+      @outage = FactoryGirl.build :outage
+    end
+
+    it "should have a down_at attribute" do
+      expect(@outage.down_at).to eql(DateTime.parse("2015-02-17T18:20:44.776959Z"))
+    end
+
+    it "should have an up_at attribute" do
+      expect(@outage.up_at).to eql(DateTime.parse("2015-02-17T18:22:35.614678Z"))
+    end
+
+    it "should have a created_at attribute" do
+      expect(@outage.created_at).to eql(DateTime.parse("2015-02-17T18:20:44.777914Z"))
+    end
+
+    it "should have a status attribute" do
+      expect(@outage.status).to eql(301)
+    end
+
+    it "should have a reason attribute" do
+      expect(@outage.reason).to eql("Expected 2xx status code. Got 301")
+    end
+
+    it "should have a headers attribute" do
+      expected_headers = {
+        :date => "Tue, 17 Feb 2015 18:20:44 GMT",
+        :server => "DNSME HTTP Redirection",
+        :location => "http://text.vote/polls",
+        :connection => "close",
+        :content_length => "0"
+      }
+      expect(@outage.headers).to eql(expected_headers)
+    end
+  end
+
+  describe "all" do
+    before :each do
+      @project_id = 1
+      @site_id = 2
+      @path = "projects/#{@project_id}/sites/#{@site_id}/outages"
+      @handler = Proc.new { |response| Outage.new(response) }
+      Honeybadger::Api::Outage.expects(:handler).returns(@handler)
+    end
+
+    it "should find all of the uptime checks" do
+      Honeybadger::Api::Request.expects(:all).with(@path, @handler).once
+      Honeybadger::Api::Outage.all(@project_id, @site_id)
+    end
+  end
+
+  describe "paginate" do
+    before :each do
+      @project_id = 1
+      @site_id = 2
+      @path = "projects/#{@project_id}/sites/#{@site_id}/outages"
+      @handler = Proc.new { |response| Outage.new(response) }
+      @filters = { some_filter: "value" }
+      Honeybadger::Api::Outage.expects(:handler).returns(@handler)
+    end
+
+    it "should paginate all of the uptime checks" do
+      Honeybadger::Api::Request.expects(:paginate).with(@path, @handler, @filters).once
+      Honeybadger::Api::Outage.paginate(@project_id, @site_id, @filters)
+    end
+  end
+end

--- a/spec/paginator_spec.rb
+++ b/spec/paginator_spec.rb
@@ -1,10 +1,10 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Honeybadger::Api::Paginator do
 
   describe "next? and previous?" do
     before :all do
-      @client_stub = stub('client')
+      @client_stub = stub("client")
     end
 
     describe "when there is one page" do

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Honeybadger::Api::Project do
 
@@ -140,7 +140,7 @@ describe Honeybadger::Api::Project do
     before :each do
       @path = "projects"
       @handler = Proc.new { |response| Project.new(response) }
-      @filters = { some_filter: 'value' }
+      @filters = { some_filter: "value" }
       Honeybadger::Api::Project.expects(:handler).returns(@handler)
     end
 

--- a/spec/site_spec.rb
+++ b/spec/site_spec.rb
@@ -63,7 +63,7 @@ describe Honeybadger::Api::Site do
       @project_id = 1
       @path = "projects/#{@project_id}/sites"
       @handler = Proc.new { |response| Site.new(response) }
-      @filters = { some_filter: 'value' }
+      @filters = { some_filter: "value" }
       Honeybadger::Api::Site.expects(:handler).returns(@handler)
     end
 

--- a/spec/site_spec.rb
+++ b/spec/site_spec.rb
@@ -1,0 +1,90 @@
+require "spec_helper"
+
+describe Honeybadger::Api::Site do
+
+  describe "initializing a new site" do
+    before :all do
+      @site = FactoryGirl.build :site
+    end
+
+    it "should have an id attribute" do
+      expect(@site.id).to eql("9eed6a7e-af77-4cc6-8c55-b7b17555330d")
+    end
+
+    it "should have an active attribute" do
+      expect(@site.active).to be true
+    end
+
+    it "should have a frequency attribute" do
+      expect(@site.frequency).to eql(5)
+    end
+
+    it "should have a last_checked_at attribute" do
+      expect(@site.last_checked_at).to eql(DateTime.parse("2016-06-15T12:57:29.646956Z"))
+    end
+
+    it "should have a match attribute" do
+      expect(@site.match).to be_nil
+    end
+
+    it "should have a match_type attribute" do
+      expect(@site.match_type).to eql("success")
+    end
+
+    it "should have a name attribute" do
+      expect(@site.name).to eql("Main site")
+    end
+
+    it "should have a state attribute" do
+      expect(@site.state).to eql("down")
+    end
+
+    it "should have an url attribute" do
+      expect(@site.url).to eql("http://www.example.com")
+    end
+  end
+
+  describe "all" do
+    before :each do
+      @project_id = 1
+      @path = "projects/#{@project_id}/sites"
+      @handler = Proc.new { |response| Site.new(response) }
+      Honeybadger::Api::Site.expects(:handler).returns(@handler)
+    end
+
+    it "should find all of the sites" do
+      Honeybadger::Api::Request.expects(:all).with(@path, @handler).once
+      Honeybadger::Api::Site.all(@project_id)
+    end
+  end
+
+  describe "paginate" do
+    before :each do
+      @project_id = 1
+      @path = "projects/#{@project_id}/sites"
+      @handler = Proc.new { |response| Site.new(response) }
+      @filters = { some_filter: 'value' }
+      Honeybadger::Api::Site.expects(:handler).returns(@handler)
+    end
+
+    it "should paginate all of the sites" do
+      Honeybadger::Api::Request.expects(:paginate).with(@path, @handler, @filters).once
+      Honeybadger::Api::Site.paginate(@project_id, @filters)
+    end
+  end
+
+  describe "find" do
+    before :each do
+      @project_id = 1
+      @site_id = 2
+      @path = "projects/#{@project_id}/sites/#{@site_id}"
+      @handler = Proc.new { |response| Site.new(response) }
+      Honeybadger::Api::Site.expects(:handler).returns(@handler)
+    end
+
+    it "should find a site" do
+      Honeybadger::Api::Request.expects(:find).with(@path, @handler).once
+      Honeybadger::Api::Site.find(@project_id, @site_id)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,8 @@
-require 'rspec'
-require 'webmock/rspec'
-require 'mocha/api'
-require 'factory_girl'
-require 'honeybadger-api'
+require "rspec"
+require "webmock/rspec"
+require "mocha/api"
+require "factory_girl"
+require "honeybadger-api"
 
 RSpec.configure do |config|
   config.color = true

--- a/spec/team_invitation_spec.rb
+++ b/spec/team_invitation_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Honeybadger::Api::TeamInvitation do
   
@@ -71,7 +71,7 @@ describe Honeybadger::Api::TeamInvitation do
       @team_id = 1
       @path = "teams/#{@team_id}/team_invitations"
       @handler = Proc.new { |response| TeamInvitation.new(response) }
-      @filters = { some_filter: 'value' }
+      @filters = { some_filter: "value" }
       Honeybadger::Api::TeamInvitation.expects(:handler).returns(@handler)
     end
 

--- a/spec/team_member_spec.rb
+++ b/spec/team_member_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Honeybadger::Api::TeamMember do
 
@@ -85,7 +85,7 @@ describe Honeybadger::Api::TeamMember do
       @team_id = 1
       @path = "teams/#{@team_id}/team_members"
       @handler = Proc.new { |response| TeamMember.new(response) }
-      @filters = { some_filter: 'value' }
+      @filters = { some_filter: "value" }
       Honeybadger::Api::TeamMember.expects(:handler).returns(@handler)
     end
 

--- a/spec/team_spec.rb
+++ b/spec/team_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Honeybadger::Api::Team do
 
@@ -42,7 +42,7 @@ describe Honeybadger::Api::Team do
     before :each do
       @path = "teams"
       @handler = Proc.new { |response| Team.new(response) }
-      @filters = { some_filter: 'value' }
+      @filters = { some_filter: "value" }
       Honeybadger::Api::Team.expects(:handler).returns(@handler)
     end
 

--- a/spec/uptime_check_spec.rb
+++ b/spec/uptime_check_spec.rb
@@ -38,7 +38,7 @@ describe Honeybadger::Api::UptimeCheck do
       Honeybadger::Api::UptimeCheck.all(@project_id, @site_id)
     end
   end
-  #
+
   describe "paginate" do
     before :each do
       @project_id = 1

--- a/spec/uptime_check_spec.rb
+++ b/spec/uptime_check_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+
+describe Honeybadger::Api::UptimeCheck do
+
+  describe "initializing a new site" do
+    before :all do
+      @uptime_check = FactoryGirl.build :uptime_check
+    end
+
+    it "should have an up attribute" do
+      expect(@uptime_check.up).to be true
+    end
+
+    it "should have a location attribute" do
+      expect(@uptime_check.location).to eql("Singapore")
+    end
+
+    it "should have a duration attribute" do
+      expect(@uptime_check.duration).to eql(1201)
+    end
+
+    it "should have a created_at attribute" do
+      expect(@uptime_check.created_at).to eql(DateTime.parse("2016-06-16T20:19:32.852569Z"))
+    end
+  end
+
+  describe "all" do
+    before :each do
+      @project_id = 1
+      @site_id = 2
+      @path = "projects/#{@project_id}/sites/#{@site_id}/uptime_checks"
+      @handler = Proc.new { |response| UptimeCheck.new(response) }
+      Honeybadger::Api::UptimeCheck.expects(:handler).returns(@handler)
+    end
+
+    it "should find all of the uptime checks" do
+      Honeybadger::Api::Request.expects(:all).with(@path, @handler).once
+      Honeybadger::Api::UptimeCheck.all(@project_id, @site_id)
+    end
+  end
+  #
+  describe "paginate" do
+    before :each do
+      @project_id = 1
+      @site_id = 2
+      @path = "projects/#{@project_id}/sites/#{@site_id}/uptime_checks"
+      @handler = Proc.new { |response| UptimeCheck.new(response) }
+      @filters = { some_filter: "value" }
+      Honeybadger::Api::UptimeCheck.expects(:handler).returns(@handler)
+    end
+
+    it "should paginate all of the uptime checks" do
+      Honeybadger::Api::Request.expects(:paginate).with(@path, @handler, @filters).once
+      Honeybadger::Api::UptimeCheck.paginate(@project_id, @site_id, @filters)
+    end
+  end
+end

--- a/spec/uptime_check_spec.rb
+++ b/spec/uptime_check_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Honeybadger::Api::UptimeCheck do
 
-  describe "initializing a new site" do
+  describe "initializing a new uptime check" do
     before :all do
       @uptime_check = FactoryGirl.build :uptime_check
     end

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Honeybadger::Api::User do
   describe "initializing a new user" do

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe "Honeybadger::Api::VERSION" do
   it "should be version 2.0.1" do

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe "Honeybadger::Api::VERSION" do
-  it "should be version 2.0.1" do
-    expect(Honeybadger::Api::VERSION).to eql("2.0.1")
+  it "should be version 2.1.0" do
+    expect(Honeybadger::Api::VERSION).to eql("2.1.0")
   end
 end


### PR DESCRIPTION
Adds support for sites, outages and uptime check endpoints.

- http://docs.honeybadger.io/guides/api.html#site-list-site-details
- http://docs.honeybadger.io/guides/api.html#site-outage-list
- http://docs.honeybadger.io/guides/api.html#site-uptime-check-list

Resolves #21 #22 #23 